### PR TITLE
Fix subtask CSV export.

### DIFF
--- a/plugins/csv.sh
+++ b/plugins/csv.sh
@@ -59,8 +59,8 @@ SELECT
   "",
   "",
   "",
-  "",
   T1.title,
+  "",
   ""
 FROM TMChecklistItem T1
 LEFT OUTER JOIN $TASKTABLE T2 ON T1.task = T2.uuid


### PR DESCRIPTION
Previously subtasks were exported in the notes column.