### PR TITLE
Update Today sort to use todayIndex instead of sorting by date, then …

### DIFF
--- a/plugins/2_today.sh
+++ b/plugins/2_today.sh
@@ -3,7 +3,7 @@
 myPluginID="$(getNextPluginID)"
 myPlugin="plugin$myPluginID"
 myPluginCommand='today'
-myPluginDescription="Shows $LIMIT_BY todays tasks ordered by index"
+myPluginDescription="Shows $LIMIT_BY tasks from today ordered by todayIndex"
 myPluginMethod='queryToday'
 
 eval "$myPlugin=('$myPluginCommand' '$myPluginDescription' '$myPluginMethod')"
@@ -30,7 +30,7 @@ LEFT OUTER JOIN $TASKTABLE HEADING ON TASK.heading = HEADING.uuid
 WHERE TASK.$ISNOTTRASHED AND TASK.$ISOPEN AND TASK.$ISTASK
 AND TASK.$ISSTARTED
 AND TASK.startdate is NOT NULL
-ORDER BY TASK.startdate, TASK.todayIndex
+ORDER BY TASK.todayIndex
 LIMIT $LIMIT_BY
 SQL
   echo "$query"


### PR DESCRIPTION
This sort was returning values that didn't match the order seen on screen in things.  The root cause was that sort was by `startdate`, then `todayIndex`.  This led to incorrect results if a task had been on the today list for more than "today".

Note that there is at least one issue I did not try to address - namely that `orderBy` is ignored for this query (and was before).